### PR TITLE
[이거성 2021.06.28]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,18 @@
 			<version>1.9.13</version>
 		</dependency>
 		
+		<!-- 	이메일 인증 관련 라이브러리 -->
+		<dependency>
+    		<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+			<version>1.4.7</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>${spring}</version>
+		</dependency>
+		
 		<!-- junit -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/sng/gdrs/AdminController.java
+++ b/src/main/java/com/sng/gdrs/AdminController.java
@@ -1,0 +1,50 @@
+package com.sng.gdrs;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.sng.gdrs.dto.AdminInfoDto;
+import com.sng.gdrs.model.service.IAdminInfoService;
+
+@Controller
+public class AdminController {
+	
+	private Logger logger = LoggerFactory.getLogger(this.getClass());
+	
+	@Autowired
+	private IAdminInfoService iaService;
+	
+	@RequestMapping(value ="/doyouknowjelly.do", method = RequestMethod.GET )
+	public String signupForm() {
+		logger.info("[signupForm] : 관리자 계정 생성 페이지로 이동 요청");
+		
+		return "admin/asignupForm";
+	}
+	
+	@RequestMapping(value = "/asignUp.do", method = RequestMethod.POST)
+	public String asignUp(AdminInfoDto dto, HttpServletResponse response) throws IOException {	
+		response.setContentType("text/html; charset=UTF-8;");
+		PrintWriter out = response.getWriter();
+		
+		boolean isc = iaService.adminSignUp(dto);
+		if(isc) {
+			out.println("<script>alert('관리자 계정 생성 완료.'); location.href='./loginForm.do'</script>");
+			out.flush();
+		}else if(!isc){
+			out.println("<script>alert('관리자 계정 생성 실패.'); location.href='./asignUp.do'</script>");
+			out.flush();
+		}
+		
+		return null;
+	}
+	
+}

--- a/src/main/java/com/sng/gdrs/UserController.java
+++ b/src/main/java/com/sng/gdrs/UserController.java
@@ -49,15 +49,12 @@ public class UserController {
 			out.println("<script>alert('잘못된 아이디 또는 비밀번호 입니다.'); location.href='./loginForm.do'</script>");
 			out.flush();
 			
-//			return "redirect:/loginForm.do";
 			return null;
 			
 		}else{
 			logger.info("[login] : 로그인 성공");
 			//로그인에 성공하면 userInfoDto을 session에 담는다
-			session.setAttribute("userInfoDto", userInfoDto);
-			
-			System.out.println(userInfoDto);
+			session.setAttribute("userInfoDto", userInfoDto);		
 			
 		}	
 		return "redirect:/index.jsp";
@@ -131,8 +128,6 @@ public class UserController {
 		UserInfoDto udto = (UserInfoDto)session.getAttribute("userInfoDto");
 		String email = udto.getEmail();
 		UserInfoDto dto = iuService.umMyPage(email);
-		System.out.println(email+"--------email값확인중 --------------");
-		System.out.println(dto+"--------dto값확인중 --------------");
 		model.addAttribute("dto" ,dto);
 		
 		logger.info("[myInfo] : 회원 정보 조회 페이지 이동 요청 : {}", dto);

--- a/src/main/java/com/sng/gdrs/UserController.java
+++ b/src/main/java/com/sng/gdrs/UserController.java
@@ -1,9 +1,11 @@
 package com.sng.gdrs;
 
 import java.io.IOException;
+
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -202,7 +204,15 @@ public class UserController {
 		return map;
 	}
 	
-	
+	@RequestMapping(value = "/emailChk.do", method = RequestMethod.POST)
+	@ResponseBody
+	public String emailChk() {
+		Random random = new Random();
+		int randomNum = random.nextInt(99999999);
+		logger.info("[T] : 난수 발생 테스트 : {}", randomNum);
+		
+		return null;
+	}
 	
 	
 	

--- a/src/main/java/com/sng/gdrs/dto/AdminInfoDto.java
+++ b/src/main/java/com/sng/gdrs/dto/AdminInfoDto.java
@@ -1,0 +1,80 @@
+package com.sng.gdrs.dto;
+
+import java.io.Serializable;
+
+public class AdminInfoDto implements Serializable{
+
+	private static final long serialVersionUID = 3370414582412709875L;
+	
+	private String email;
+	private String password;
+	private String name;
+	private int admingrade;
+	private String delflag;
+	                          
+	public AdminInfoDto() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public AdminInfoDto(String email, String password, String name, int admingrade, String delflag) {
+		super();
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.admingrade = admingrade;
+		this.delflag = delflag;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getAdmingrade() {
+		return admingrade;
+	}
+
+	public void setAdmingrade(int admingrade) {
+		this.admingrade = admingrade;
+	}
+
+	public String getDelflag() {
+		return delflag;
+	}
+
+	public void setDelflag(String delflag) {
+		this.delflag = delflag;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	@Override
+	public String toString() {
+		return "AdminInfoDto [email=" + email + ", password=" + password + ", name=" + name + ", admingrade="
+				+ admingrade + ", delflag=" + delflag + "]";
+	}
+
+	
+	
+}

--- a/src/main/java/com/sng/gdrs/model/dao/AdminInfoDaoImpl.java
+++ b/src/main/java/com/sng/gdrs/model/dao/AdminInfoDaoImpl.java
@@ -1,0 +1,28 @@
+package com.sng.gdrs.model.dao;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+import com.sng.gdrs.dto.AdminInfoDto;
+
+@Repository
+public class AdminInfoDaoImpl implements IAdminInfoDao {
+
+	@Autowired
+	private SqlSessionTemplate sqlSession;
+	
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	
+	@Override
+	public boolean adminSignUp(AdminInfoDto dto) {
+		String enPassword = passwordEncoder.encode(dto.getPassword());
+		dto.setPassword(enPassword);
+		
+		int n = sqlSession.insert("com.sng.gdrs.model.dao.IAdminInfoDao.adminSignUp", dto);
+		return (n>0)?true:false;
+	}
+
+}

--- a/src/main/java/com/sng/gdrs/model/dao/IAdminInfoDao.java
+++ b/src/main/java/com/sng/gdrs/model/dao/IAdminInfoDao.java
@@ -1,0 +1,15 @@
+package com.sng.gdrs.model.dao;
+
+import com.sng.gdrs.dto.AdminInfoDto;
+
+public interface IAdminInfoDao {
+
+	/**
+	 * 회원가입
+	 * 
+	 * @param dto
+	 * @return
+	 */
+	public boolean adminSignUp(AdminInfoDto dto);
+	
+}

--- a/src/main/java/com/sng/gdrs/model/service/AdminInfoServiceImpl.java
+++ b/src/main/java/com/sng/gdrs/model/service/AdminInfoServiceImpl.java
@@ -1,0 +1,26 @@
+package com.sng.gdrs.model.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.sng.gdrs.dto.AdminInfoDto;
+import com.sng.gdrs.model.dao.IAdminInfoDao;
+
+@Service
+public class AdminInfoServiceImpl implements IAdminInfoService {
+	
+	private Logger logger = LoggerFactory.getLogger(this.getClass());
+	
+	@Autowired
+	private IAdminInfoDao aDao;
+
+	// 관리자 회원가입
+	@Override
+	public boolean adminSignUp(AdminInfoDto dto) {
+		logger.info("adminSignUp 회원가입 : {} ", dto);
+		return aDao.adminSignUp(dto);
+	}
+
+}

--- a/src/main/java/com/sng/gdrs/model/service/IAdminInfoService.java
+++ b/src/main/java/com/sng/gdrs/model/service/IAdminInfoService.java
@@ -1,0 +1,10 @@
+package com.sng.gdrs.model.service;
+
+import com.sng.gdrs.dto.AdminInfoDto;
+
+public interface IAdminInfoService {
+	
+	//회원가입
+	public boolean adminSignUp(AdminInfoDto dto);
+
+}

--- a/src/main/resources/sqls/AdminInfo_Statement.xml
+++ b/src/main/resources/sqls/AdminInfo_Statement.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.sng.gdrs.model.dao.IAdminInfoDao">
+  
+  <!-- 	관리자 회원가입 -->
+	<insert id="adminSignUp"  parameterType="AdminInfoDto">
+		INSERT INTO ADMININFO(
+							EMAIL, PASSWORD, NAME)
+				VALUES(#{email}, #{password}, #{name})
+	</insert>
+  
+</mapper>

--- a/src/main/resources/sqls/UserInfo_Statement.xml
+++ b/src/main/resources/sqls/UserInfo_Statement.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="com.sng.gdrs.model.dao.IUserInfoDao">
+	
 <!-- 	로그인 -->
 	<select id="umLogin" parameterType="java.util.Map" resultType="UserInfoDto">
-		SELECT EMAIL, NAME, DELFLAG, EMAILCHECK
-      	  FROM USERINFO u 
-      	  WHERE EMAIL =#{email}
-              AND PASSWORD =#{password}
-              AND DELFLAG ='N'
+		SELECT EMAIL , NAME , DELFLAG
+		FROM (
+			SELECT EMAIL , NAME , DELFLAG , PASSWORD 
+				FROM USERINFO u 
+			UNION
+			SELECT EMAIL , NAME , DELFLAG , PASSWORD 
+				FROM ADMININFO a
+		)
+		WHERE EMAIL = #{email}
+			AND PASSWORD = #{password}
+			AND DELFLAG = 'N'
 	</select>
 
-<!-- 회원가입 -->
+<!-- 지원자 회원가입 -->
 	<insert id="umSignUp" parameterType="UserInfoDto">
 		INSERT INTO USERINFO (
                            EMAIL, PASSWORD, NAME, 
@@ -22,8 +29,12 @@
 <!-- 이메일 중복검사 -->
 	<select id="umDuplicate" parameterType="java.lang.String" resultType="java.lang.String">
 		SELECT EMAIL
-       	 FROM USERINFO u 
-       	 WHERE EMAIL = #{email}
+			FROM (SELECT EMAIL 
+						FROM USERINFO u 
+						UNION
+					  SELECT EMAIL 
+						FROM ADMININFO a)
+		WHERE EMAIL = #{email}
 	</select>
 
 <!-- 이메일 인증. -->
@@ -62,17 +73,25 @@
 <!-- 비밀번호 암호화에 사용될 것 -->
 <!-- 아이디로 로그인 -->
 	<select id="umEmailSecurity" parameterType="java.lang.String" resultType="UserInfoDto">
-		SELECT EMAIL, NAME, EMAILCHECK
-      	  FROM USERINFO u 
-      	  WHERE EMAIL =  #{email}
-      	  AND DELFLAG ='N'
+		SELECT EMAIL, NAME, DELFLAG 
+			FROM (SELECT EMAIL, NAME, DELFLAG  
+						FROM USERINFO u 
+					UNION
+					 SELECT EMAIL, NAME, DELFLAG  
+						FROM ADMININFO a)
+			WHERE EMAIL = #{email}
+			AND DELFLAG ='N'
 	</select>
 
 <!-- 비밀번호 확인 -->
 	<select id="umPwSecurity" parameterType="java.lang.String" resultType="java.lang.String">
 		SELECT PASSWORD 
-      	  FROM USERINFO u 
-      	  WHERE EMAIL =  #{email}
+			FROM (SELECT EMAIL, PASSWORD 
+						FROM USERINFO u 
+					  UNION
+					  SELECT EMAIL, PASSWORD 
+						FROM ADMININFO a)
+			WHERE EMAIL = #{email}
 	</select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/spring/appServlet/email-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/email-context.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="javaMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+		 <property name="host" value="smtp.gmail.com" />
+        <property name="port" value="587" />
+        <property name="username" value="dlrjtjd0615@gmail.com"/>
+        <property name="password">					
+			<value>												
+				<![CDATA[mm040742!]]> 					
+			</value> 											
+		</property> 
+        <property name="javaMailProperties">
+            <props>
+                <prop key="mail.smtp.debug">true</prop>
+                <prop key="mail.smtp.auth">true</prop>
+                <prop key="mail.transport.protocol">smtp</prop>
+                <prop key="mail.smtp.starttls.enable">true</prop>
+            </props>
+        </property>
+	</bean>
+
+</beans>

--- a/src/main/webapp/WEB-INF/spring/mybatis/Configuration.xml
+++ b/src/main/webapp/WEB-INF/spring/mybatis/Configuration.xml
@@ -4,6 +4,7 @@
 
 	<!-- DTO나 VO 같은 데이터전달 객체 선언 typeAlias -->
 	<typeAliases>
+		<typeAlias type="com.sng.gdrs.dto.AdminInfoDto" alias="AdminInfoDto" />
 		<typeAlias type="com.sng.gdrs.dto.UserInfoDto" alias="UserInfoDto" />
 		<typeAlias type="com.sng.gdrs.dto.RecruitDto" alias="RecruitDto" />
 		<typeAlias type="com.sng.gdrs.dto.CodeDto" alias="CodeDto" />
@@ -13,6 +14,7 @@
 	<mappers>
 		<mapper resource="sqls/Code_Statement.xml" />
 		<mapper resource="sqls/UserInfo_Statement.xml" />
+		<mapper resource="sqls/AdminInfo_Statement.xml" />
 		<mapper resource="sqls/Recruit_Statement.xml" />
 	</mappers>
 

--- a/src/main/webapp/WEB-INF/views/admin/asignupForm.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/asignupForm.jsp
@@ -7,11 +7,11 @@
 <script type="text/javascript" src="./js/user.js"></script>
 
 <div class="container">
-	<form action="./signUp.do" method="post"  onsubmit="return signupChk(this);">
+	<form action="./asignUp.do" method="post"  onsubmit="return signupChk(this);">
 	<div class="box">
 		<div class="card">
 		<div class="card-body">
-			<div class="mt-3 fs-4 fw-bold">회원가입</div>
+			<div class="mt-3 fs-4 fw-bold">관리자 계정 생성</div>
 				<div class="input-group my-3">
  					<span class="input-group-text" >이메일</span>
   					<input type="text" name="email" id="email" class="form-control"  required readonly>
@@ -23,22 +23,14 @@
 				</div>
 				<div class="input-group my-3">
  					<span class="input-group-text" >비밀번호&nbsp;확인</span>
-  					<input type="password" name="passwordChk" id="passwordChk" class="form-control" onchange="pwCheck()" aria-label="Username"  required>
+  					<input type="password" name="passwordChk" id="passwordChk" class="form-control" onchange="pwCheck()"  required>
 				</div>
 				<div>
   					<span id="check"></span>
 				</div>
 				<div class="input-group my-3">
  					<span class="input-group-text" >이&nbsp;름</span>
-  					<input type="text" name="name" id="name" class="form-control"  placeholder="ex) 이젤리" required>
-				</div>
-				<div class="input-group my-3">
- 					<span class="input-group-text" >생년월일</span>
-  					<input type="text" name="birth" id="birth" class="form-control"  placeholder="ex) 1993-06-14" required>
-				</div>
-				<div class="input-group my-3">
- 					<span class="input-group-text" >핸드폰번호</span>
-  					<input type="text" name="phone" id="phone" class="form-control"  placeholder="ex) 010-1234-5678" required>
+  					<input type="text" name="name" id="name" class="form-control"  required>
 				</div>
 		</div>	
 		</div>

--- a/src/main/webapp/WEB-INF/views/user/loginForm.jsp
+++ b/src/main/webapp/WEB-INF/views/user/loginForm.jsp
@@ -13,12 +13,12 @@
 			<div class="card-body">
 				<div class="mt-3 fs-4 fw-bold">로그인</div>
 				<div class="input-group my-3">
- 					<span class="input-group-text" id="basic-addon1">이메일</span>
-  					<input type="text" name="email" id="email" class="form-control" aria-label="Username" aria-describedby="basic-addon1">
+ 					<span class="input-group-text" >이메일</span>
+  					<input type="text" name="email" id="email" class="form-control" >
 				</div>
 				<div class="input-group my-3">
- 					<span class="input-group-text" id="basic-addon1">비밀번호</span>
-  					<input type="password" name="password" id="password" class="form-control" aria-label="Username" aria-describedby="basic-addon1">
+ 					<span class="input-group-text" >비밀번호</span>
+  					<input type="password" name="password" id="password" class="form-control" >
 				</div>
 			</div>
 		</div>

--- a/src/main/webapp/WEB-INF/views/user/myInfo.jsp
+++ b/src/main/webapp/WEB-INF/views/user/myInfo.jsp
@@ -16,11 +16,17 @@
 				</div>
 				<div  class="my-3 fw-light">
 					이메일
-					<p class="fw-normal fs-6">${dto.email}</p>
+					<div class="fw-normal fs-6">${dto.email}
+					</div>
+						<c:if test="${userInfoDto.emailcheck == 'N'}">
+							<input type="button" value="이메일 인증" class="btn btn-outline-success" onclick="emailChk()">
+						</c:if>		
 				</div>
 				<div  class="my-3 fw-light">
-					비밀번호
-					<p class="fw-normal fs-6" onclick="modifyPw()"><a class="modifyPw">비밀번호 변경하기</a></p>
+					<div>
+					비밀번호<br>
+						<input type="button" onclick="modifyPw()" value="비밀번호 변경" class="btn btn-outline-success ">
+					</div>
 				</div>
 				<div  class="my-3 fw-light">
 					휴대폰 번호
@@ -33,7 +39,7 @@
 			</div>
 		</div>
     	<div class="my-3" align="right">
-	    	<input type="submit" class="btn btn-danger " value="계정삭제" onclick="delFlagChk()">
+	    	<input type="submit" class="btn btn-outline-danger"  value="계정삭제" onclick="delFlagChk()">
     	</div>
 
 	</div>

--- a/src/main/webapp/WEB-INF/views/user/signupAgree.jsp
+++ b/src/main/webapp/WEB-INF/views/user/signupAgree.jsp
@@ -13,7 +13,7 @@
 				<div class="my-3 fs-4 fw-bold">[필수]개인정보 수집 및 이용 동의</div>
 				<label  class="my-2 fw-bold" for="floatingTextarea">개인정보 수집 및 이용에 대한 안내</label>
 				<div class="form-floating">
-					<textarea class="form-control" placeholder="Leave a comment here" id="floatingTextarea" readonly>동의하세요</textarea>
+					<textarea class="form-control" id="floatingTextarea" readonly>동의하세요</textarea>
 				</div>
 				<div class="my-2">
 					<input id="signupAgreeChk" type="checkbox">

--- a/src/main/webapp/WEB-INF/views/user/signupForm.jsp
+++ b/src/main/webapp/WEB-INF/views/user/signupForm.jsp
@@ -15,7 +15,7 @@
 				<div class="input-group my-3">
  					<span class="input-group-text" id="basic-addon1">이메일</span>
   					<input type="text" name="email" id="email" class="form-control" aria-label="Username" aria-describedby="basic-addon1" required readonly>
-					<input type="button" value="중복확인" class="btn btn-success" onclick="duplicate()">
+					<input type="button" value="중복확인" class="btn btn-outline-success" onclick="duplicate()">
 				</div>
 				<div class="input-group my-3">
  					<span class="input-group-text" id="basic-addon1">비밀번호</span>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,7 +24,7 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
 			/WEB-INF/spring/appServlet/application-context.xml
-			/WEB-INF/spring/appServlet/security-context.xml
+			/WEB-INF/spring/appServlet/security-context.xml		
 		</param-value>
 	</context-param>
 
@@ -41,6 +41,7 @@
 			<param-value>
 				/WEB-INF/spring/appServlet/servlet-context.xml
 				/WEB-INF/spring/appServlet/aop-context.xml
+				/WEB-INF/spring/appServlet/email-context.xml
 			</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>

--- a/src/main/webapp/css/user.css
+++ b/src/main/webapp/css/user.css
@@ -13,6 +13,3 @@
 	 justify-content: center;
 }
 
-.modifyPw{
-	cursor: pointer;
-}

--- a/src/main/webapp/js/user.js
+++ b/src/main/webapp/js/user.js
@@ -45,7 +45,7 @@ function duplicate(){
 	
 	(async () => {
 
-		const { value: email } = await Swal.fire({     // Swal 빨간줄 이클립스에서 호환 안되는 듯 함
+		const { value: email } = await Swal.fire({    
 		title: '이메일 중복검사',
 		input: 'email',
 		inputLabel: '사용하실 이메일을 입력해 주세요',
@@ -89,10 +89,10 @@ function duplicate(){
 					
 				   }
 			})
-	 }  // if문
+	 }  // if문 종료
 	})()  
 
-}  // function
+}  // function 종료
 
 //비밀번호 중복확인
 function pwCheck(){
@@ -135,15 +135,16 @@ function modifyPw(){
 	// 비빌번호 변경전 기존 비밀번호 확인
 	(async () => {
 
-		const { value: password } = await Swal.fire({     // Swal 빨간줄 이클립스에서 호환 안되는 듯 함
+		const { value: password } = await Swal.fire({     
 		title: '비밀번호 변경',
 		input: 'password',
 		inputLabel: '현재 비밀번호를 입력해 주세요',
+		
 		confirmButtonText: '확인',	
 		showCancelButton: true,
 		cancelButtonColor: 'gray',
 		cancelButtonText: '취소'
-	}); // Swal.fire
+	}); // Swal.fire 종료
 		// 확인 성공시 변경할 비밀번호 입력
 	 if(password){
 		 $.ajax({
@@ -210,7 +211,7 @@ function modifyPw(){
 					
 				   }
 			})
-	 }  // if문
+	 }  // if문 종료
 	})()  
 	
 }
@@ -221,7 +222,7 @@ function delFlagChk(){
 	// 계정 삭제 전 비밀번호 확인
 	(async () => {
 
-		const { value: password } = await Swal.fire({     // Swal 빨간줄 이클립스에서 호환 안되는 듯 함
+		const { value: password } = await Swal.fire({     
 		title: '계정 삭제',
 		input: 'password',
 		inputLabel: '비밀번호를 입력해 주세요',
@@ -229,7 +230,7 @@ function delFlagChk(){
 		showCancelButton: true,
 		cancelButtonColor: 'gray',
 		cancelButtonText: '취소'
-	}); // Swal.fire
+	}); // Swal.fire 종료
 		// 확인 성공시 변경할 비밀번호 입력
 	 if(password){
 		 $.ajax({
@@ -292,7 +293,7 @@ function delFlagChk(){
 					
 				   }
 			})
-	 }  // if문
+	 }  // if문 종료
 	})()  
 	
 }

--- a/src/main/webapp/js/user.js
+++ b/src/main/webapp/js/user.js
@@ -70,7 +70,7 @@ function duplicate(){
 							text:'아이디를 사용 하시겠습니까?',
 							confirmButtonText: '아이디 사용',	
 							showCancelButton: true,
-							cancelButtonColor: 'green',
+							cancelButtonColor: 'gray',
 							cancelButtonText: '취소'
 						}).then((result) => {
 							if (result.isConfirmed) {
@@ -141,7 +141,7 @@ function modifyPw(){
 		inputLabel: '현재 비밀번호를 입력해 주세요',
 		confirmButtonText: '확인',	
 		showCancelButton: true,
-		cancelButtonColor: 'green',
+		cancelButtonColor: 'gray',
 		cancelButtonText: '취소'
 	}); // Swal.fire
 		// 확인 성공시 변경할 비밀번호 입력
@@ -163,7 +163,7 @@ function modifyPw(){
 							    '<input type="password" id="swal-input2" class="swal2-input">',
 							confirmButtonText: '확인',	
 							showCancelButton: true,
-							cancelButtonColor: 'green',
+							cancelButtonColor: 'gray',
 							cancelButtonText: '취소',
 
 						}).then((result) => {
@@ -227,7 +227,7 @@ function delFlagChk(){
 		inputLabel: '비밀번호를 입력해 주세요',
 		confirmButtonText: '확인',	
 		showCancelButton: true,
-		cancelButtonColor: 'green',
+		cancelButtonColor: 'gray',
 		cancelButtonText: '취소'
 	}); // Swal.fire
 		// 확인 성공시 변경할 비밀번호 입력
@@ -246,7 +246,7 @@ function delFlagChk(){
 							text:'계정을 정말 삭제 하시겠습니까?',
 							confirmButtonText: '확인',	
 							showCancelButton: true,
-							cancelButtonColor: 'green',
+							cancelButtonColor: 'gray',
 							cancelButtonText: '취소',
 							
 							//계정 삭제 후 로그아웃 처리
@@ -265,8 +265,14 @@ function delFlagChk(){
 												title:'계정 삭제 성공',
 												html:'계정이 삭제되었습니다.<br>  그동안 이용해주셔서 감사합니다.',
 												confirmButtonText: '확인'
-											})
+											}).then((result) => {
+												//계정삭제 alert 후 세션삭제하고 로그아웃
+											if(result.isConfirmed){	
 											location.replace("./logout.do");
+											}else{
+											location.replace("./logout.do");
+											}
+											})
 										}
 									}
 								})
@@ -279,7 +285,8 @@ function delFlagChk(){
 						Swal.fire({
 							icon:'error',
 							title:'잘못된 비밀번호 입니다',
-							confirmButtonText: '확인'
+							confirmButtonText: '확인',
+							
 						})
 					}
 					
@@ -290,7 +297,24 @@ function delFlagChk(){
 	
 }
 
-	
-
+	//이메일 인증
+function emailChk(){
+	$.ajax({
+		url:"./emailChk.do",
+		type:"post",
+		async:"true",
+		success: function(){
+			Swal.fire({
+				title:'이메일 인증',
+				html:'이메일로 전송된 인증번호를 입력해 주세요.',
+				input:'text',
+				confirmButtonText: '확인',	
+				showCancelButton: true,
+				cancelButtonColor: 'gray',
+				cancelButtonText: '취소',
+			})
+		}
+	})
+}
 
 


### PR DESCRIPTION
-- 계정삭제후 sweetalert 무시하고 메인으로 이동하던 현상 수정
-- pom.xml 이메일 인증 관련 라이브러리추가
-- email-context.xml 추가 및 web.xml에 등록
-- 로그인 같은창에서 지원자, 관리자 계정 둘다 로그인 가능하게 수정 
-- 회원가입 아이디 중복확인 지원자 관리자 둘다에서 중복안되게 수정 
-- 관리자 계정생성 관련 Dto, Dao, Service, 페이지 생성 및 암호화 관련 처리
-- 불필요한 주석및 id Syso 제거